### PR TITLE
fix(scripts): make run_eval_coco seed-safe and robust

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,8 @@ Additional evaluation scripts are provided in `scripts/`:
 ```bash
 bash scripts/run_eval.sh        # STS evaluation
 bash scripts/run_eval_coco.sh   # COCO retrieval evaluation
+# or choose a specific checkpoint seed:
+SEED=1 bash scripts/run_eval_coco.sh
 ```
 
 ---

--- a/README_zh.md
+++ b/README_zh.md
@@ -173,6 +173,8 @@ python src/evaluation.py \
 ```bash
 bash scripts/run_eval.sh        # STS 评估
 bash scripts/run_eval_coco.sh   # COCO 检索评估
+# 或显式指定 checkpoint 对应的 seed：
+SEED=1 bash scripts/run_eval_coco.sh
 ```
 
 ---

--- a/scripts/run_eval_coco.sh
+++ b/scripts/run_eval_coco.sh
@@ -1,4 +1,10 @@
-export CUDA_VISIBLE_DEVICES=1
+#!/bin/bash
+
+# Run STS evaluation for a model trained on wiki+coco.
+set -euo pipefail
+
+export CUDA_VISIBLE_DEVICES="${CUDA_VISIBLE_DEVICES:-1}"
+SEED="${SEED:-1}"
 
 OUT_DIR=result/mix_coco/best/${SEED}/mse
 


### PR DESCRIPTION
## Summary
- fix undefined SEED usage in run_eval_coco script
- add shebang and strict shell mode (set -euo pipefail)
- allow overriding CUDA device and SEED via environment variables
- update README and README_zh with explicit SEED usage example

## Validation
- bash -n scripts/run_eval_coco.sh