### PR TITLE
feat(tool): add batch file search and index guards

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,24 @@ for sent_a, sent_b, score in pairs:
     print(f"{score:.3f} | {sent_a} <> {sent_b}")
 ```
 
+### Utility: Batch Search from Query File
+
+You can run retrieval for many queries at once from a text file
+(one query per line):
+
+```python
+from src.tool import SimCSE
+
+simcse = SimCSE("Model/DALR")
+simcse.build_index("data/coco_random_captions.txt", use_faiss=False)
+batch_results = simcse.search_from_file(
+    "data/flickr_random_captions.txt",
+    top_k=3,
+    threshold=0.5,
+)
+print(batch_results[0])  # top-3 results for the first query line
+```
+
 ---
 
 ## Evaluation

--- a/README_zh.md
+++ b/README_zh.md
@@ -154,6 +154,23 @@ for sent_a, sent_b, score in pairs:
     print(f"{score:.3f} | {sent_a} <> {sent_b}")
 ```
 
+### 工具功能：从查询文件批量检索
+
+你可以直接从文本文件批量执行检索（每行一个查询句）：
+
+```python
+from src.tool import SimCSE
+
+simcse = SimCSE("Model/DALR")
+simcse.build_index("data/coco_random_captions.txt", use_faiss=False)
+batch_results = simcse.search_from_file(
+    "data/flickr_random_captions.txt",
+    top_k=3,
+    threshold=0.5,
+)
+print(batch_results[0])  # 第一条查询对应的 top-3 结果
+```
+
 ---
 
 ## 评估

--- a/src/tool.py
+++ b/src/tool.py
@@ -44,6 +44,20 @@ class SimCSE:
         else:
             self.pooler = "cls"
 
+    def _load_sentences_from_file(self, file_path: str) -> List[str]:
+        sentences = []
+        with open(file_path, encoding="utf-8") as f:
+            logging.info("Loading sentences from %s ...", file_path)
+            for line in tqdm(f):
+                sentence = line.rstrip()
+                if sentence:
+                    sentences.append(sentence)
+        return sentences
+
+    def _ensure_index_ready(self):
+        if self.index is None or "index" not in self.index or "sentences" not in self.index:
+            raise ValueError("Index is not built. Call `build_index(...)` first.")
+
     def encode(self, sentence: Union[str, List[str]],
                 device: str = None,
                 return_numpy: bool = False,
@@ -132,14 +146,9 @@ class SimCSE:
                 logger.warning("Fail to import faiss. If you want to use faiss, install faiss through PyPI. Now the program continues with brute force search.")
                 use_faiss = False
 
-        # if the input sentence is a string, we assume it's the path of file that stores various sentences
+        # if the input is a string path, load one sentence per line
         if isinstance(sentences_or_file_path, str):
-            sentences = []
-            with open(sentences_or_file_path) as f:
-                logging.info("Loading sentences from %s ..." % (sentences_or_file_path))
-                for line in tqdm(f):
-                    sentences.append(line.rstrip())
-            sentences_or_file_path = sentences
+            sentences_or_file_path = self._load_sentences_from_file(sentences_or_file_path)
 
         logger.info("Encoding embeddings for sentences...")
         embeddings = self.encode(sentences_or_file_path, device=device, batch_size=batch_size, normalize_to_unit=True, return_numpy=True)
@@ -179,15 +188,11 @@ class SimCSE:
     def add_to_index(self, sentences_or_file_path: Union[str, List[str]],
                         device: str = None,
                         batch_size: int = 64):
+        self._ensure_index_ready()
 
-        # if the input sentence is a string, we assume it's the path of file that stores various sentences
+        # if the input is a string path, load one sentence per line
         if isinstance(sentences_or_file_path, str):
-            sentences = []
-            with open(sentences_or_file_path) as f:
-                logging.info("Loading sentences from %s ..." % (sentences_or_file_path))
-                for line in tqdm(f):
-                    sentences.append(line.rstrip())
-            sentences_or_file_path = sentences
+            sentences_or_file_path = self._load_sentences_from_file(sentences_or_file_path)
 
         logger.info("Encoding embeddings for sentences...")
         embeddings = self.encode(sentences_or_file_path, device=device, batch_size=batch_size, normalize_to_unit=True, return_numpy=True)
@@ -199,12 +204,33 @@ class SimCSE:
         self.index["sentences"] += sentences_or_file_path
         logger.info("Finished")
 
+    def search_from_file(
+                self,
+                query_file_path: str,
+                device: str = None,
+                threshold: float = 0.6,
+                top_k: int = 5) -> List[List[Tuple[str, float]]]:
+        self._ensure_index_ready()
+        queries = self._load_sentences_from_file(query_file_path)
+        if not queries:
+            return []
+        results = self.search(
+            queries=queries,
+            device=device,
+            threshold=threshold,
+            top_k=top_k,
+        )
+        if isinstance(results, list) and (not results or isinstance(results[0], list)):
+            return results
+        return [results]
+
 
 
     def search(self, queries: Union[str, List[str]],
                 device: str = None,
                 threshold: float = 0.6,
                 top_k: int = 5) -> Union[List[Tuple[str, float]], List[List[Tuple[str, float]]]]:
+        self._ensure_index_ready()
 
         if not self.is_faiss_index:
             if isinstance(queries, list):


### PR DESCRIPTION
## Summary
- refactor repeated sentence-file loading logic into a shared helper in SimCSE
- add explicit index readiness guard for add_to_index/search paths with clearer errors
- add search_from_file(...) to run retrieval for many queries from a text file
- update README and README_zh with usage examples

## Why this matters
- cleaner tool.py structure with less duplicated code
- safer failure mode when index is not prepared
- better practical usability for large batch retrieval jobs

## Validation
- python3 -m compileall src/tool.py